### PR TITLE
Fixed a typo in the word block

### DIFF
--- a/_notebooks/2022-03-26-angr_notes.ipynb
+++ b/_notebooks/2022-03-26-angr_notes.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0ef89271-ef86-417a-b726-96f3dec4e03b",
+   "id": "1b0b2477",
    "metadata": {},
    "source": [
     "## Overview \n",
@@ -57,7 +57,7 @@
     "- The address of the DISPATCHER start\n",
     "  - It may be possible to determine this heuristically as many bb will jmp to this address\n",
     "- The STATE variable \n",
-    "  - The STATE variable is the variable used to pass the STATE to the DISPATCHER. In simple CFF cases the same variable is used throughout the original code bloacks but in more complex CFF this cannot be relied on.\n",
+    "  - The STATE variable is the variable used to pass the STATE to the DISPATCHER. In simple CFF cases the same variable is used throughout the original code blocks but in more complex CFF this cannot be relied on.\n",
     "- The address of each of the original code basic blocks \n",
     "  - This may not be needed initially depending on the strategy. It maybe be possible to recover these during symbolic execution.\n",
     "\n",
@@ -1994,7 +1994,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -2008,7 +2008,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.8.10"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
My first pull request.  Updated the statement "The STATE variable is the variable used to pass the STATE to the DISPATCHER. In simple CFF cases the same variable is used throughout the original code bloacks but in more complex CFF this cannot be relied on."  This is just a typo.